### PR TITLE
chore: gcc 13 requires explicit imporing of std lib components

### DIFF
--- a/src/detail/encoder.cpp
+++ b/src/detail/encoder.cpp
@@ -3,6 +3,7 @@
 
 #include <salzaverde/detail/encoder.h>
 
+#include <cstdint>
 #include <iostream>
 #include <regex>
 


### PR DESCRIPTION
[Reference](https://gcc.gnu.org/gcc-13/porting_to.html)